### PR TITLE
Show Supabase import errors in dashboard modal

### DIFF
--- a/adm/importar_noticias_supabase.php
+++ b/adm/importar_noticias_supabase.php
@@ -67,6 +67,13 @@ $created   = (int) ($summary['created_news'] ?? 0);
 $skipped   = (int) ($summary['skipped'] ?? 0);
 $errors    = $summary['errors'] ?? [];
 
+$_SESSION['supabase_import_summary'] = [
+    'processed'    => $processed,
+    'created_news' => $created,
+    'skipped'      => $skipped,
+    'errors'       => $errors,
+];
+
 $mensajePartes = [
     sprintf('Importación completada. Procesadas: %d.', $processed),
     sprintf('Nuevas: %d.', $created),


### PR DESCRIPTION
## Summary
- add an exception class so Supabase imports can expose SQL and parameter context when they fail
- persist the latest import summary in the session and surface it through a Bootstrap modal on the news dashboard
- display processed counts and detailed Supabase record, SQL, and database error information for each failed import

## Testing
- php -l integracion_supabase_gpt.php
- php -l adm/importar_noticias_supabase.php
- php -l adm/news.php

------
https://chatgpt.com/codex/tasks/task_e_68fbdf7f5b208328ad041bd006019934