### PR TITLE
Enable news image updates and add ToolMAPE navigation link

### DIFF
--- a/includes/layout/navbar.php
+++ b/includes/layout/navbar.php
@@ -5,6 +5,7 @@ if (session_status() === PHP_SESSION_NONE) {
 
 $sessionActive = false;
 $sessionTarget = 'adm/user.php';
+$sessionUserName = 'Usuario';
 
 if (isset($_SESSION['login'])) {
     $sessionLifetime = 12000; // 200 minutos, como en el panel de administración
@@ -28,6 +29,11 @@ if (isset($_SESSION['login'])) {
         if (!in_array($nivel, [1, 2], true)) {
             $sessionTarget = 'adm/news.php';
         }
+
+        $sessionUserName = trim((string) ($_SESSION['nombre'] ?? ''));
+        if ($sessionUserName === '') {
+            $sessionUserName = 'Usuario';
+        }
     }
 }
 ?>
@@ -49,8 +55,11 @@ if (isset($_SESSION['login'])) {
                     <a class="nav-link" href="#contact">Contacto</a>
                 </li>
                 <li class="nav-item">
+                    <a class="nav-link" href="http://localhost:56931/#/calculadora">ToolMAPE</a>
+                </li>
+                <li class="nav-item">
                     <?php if ($sessionActive): ?>
-                        <a class="nav-link" href="<?php echo htmlspecialchars($sessionTarget, ENT_QUOTES, 'UTF-8'); ?>">Iniciar Sesión</a>
+                        <a class="nav-link" href="<?php echo htmlspecialchars($sessionTarget, ENT_QUOTES, 'UTF-8'); ?>"><?php echo htmlspecialchars($sessionUserName, ENT_QUOTES, 'UTF-8'); ?></a>
                     <?php else: ?>
                         <a class="nav-link" href="#" onclick="openLoginModal(); return false;">Iniciar Sesión</a>
                     <?php endif; ?>

--- a/includes/repositories/NewsRepository.php
+++ b/includes/repositories/NewsRepository.php
@@ -85,17 +85,29 @@ class NewsRepository
         int $newsId,
         string $title,
         string $body,
-        int $status
+        int $status,
+        ?string $imageName = null
     ): bool {
-        $sql = 'UPDATE noticias SET titulo = ?, cuerpo = ?, estado = ? WHERE idNoticia = ?';
-
         $link = $this->connection->GetLink();
-        $statement = $link->prepare($sql);
-        if ($statement === false) {
-            return false;
+
+        if ($imageName !== null) {
+            $sql = 'UPDATE noticias SET titulo = ?, cuerpo = ?, estado = ?, imagen = ? WHERE idNoticia = ?';
+            $statement = $link->prepare($sql);
+            if ($statement === false) {
+                return false;
+            }
+
+            $statement->bind_param('ssisi', $title, $body, $status, $imageName, $newsId);
+        } else {
+            $sql = 'UPDATE noticias SET titulo = ?, cuerpo = ?, estado = ? WHERE idNoticia = ?';
+            $statement = $link->prepare($sql);
+            if ($statement === false) {
+                return false;
+            }
+
+            $statement->bind_param('ssii', $title, $body, $status, $newsId);
         }
 
-        $statement->bind_param('ssii', $title, $body, $status, $newsId);
         $success = $statement->execute();
         $statement->close();
 


### PR DESCRIPTION
## Summary
- allow administrators to upload and replace images when editing news entries
- update the edit modal with image preview, upload field, and validation feedback
- add a ToolMAPE shortcut in the navbar and show the logged-in user's name instead of "Iniciar Sesión"

## Testing
- php -l adm/manage_news.php
- php -l includes/repositories/NewsRepository.php
- php -l includes/layout/navbar.php

------
https://chatgpt.com/codex/tasks/task_e_68fbe4bfb584832889060c5c493cf036